### PR TITLE
Fix video test display bug on cleanup

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -775,7 +775,7 @@ static void showVideoSuite(size_t index) {
 	memset((void*) 0x06000500, 0, 0x300);
 	REG_DISPCNT = dispcnt;
 	REG_DISPSTAT &= ~0x0030;
-	REG_BG1CNT = CHAR_BASE(1) | SCREEN_BASE(0);
+	REG_BG1CNT = CHAR_BASE(1) | SCREEN_BASE(1);
 	REG_BG1VOFS = -4;
 	irqDisable(IRQ_VCOUNT | IRQ_HBLANK);
 	irqInit();


### PR DESCRIPTION
ScreenBase block cleanup after video tests was not updated to match changes on previous commit 2a8eca19. Now you can return to the menus from the video tests.

Fixes issue #25 